### PR TITLE
El fichero debe llevar el número de palabras al principio

### DIFF
--- a/words.dic
+++ b/words.dic
@@ -1,3 +1,4 @@
+24
 API
 License
 GPL


### PR DESCRIPTION
Es una chuminá, pero es así.